### PR TITLE
Make python-markdown work with other kernels

### DIFF
--- a/nbextensions/usability/python-markdown/main.js
+++ b/nbextensions/usability/python-markdown/main.js
@@ -61,7 +61,13 @@ define([
                         if (out_data.msg_type === "error") {
                             var text = "**" + out_data.content.ename + "**: " +  out_data.content.evalue;
                             html = marked(text);
-                        } else if (out_data.msg_type === "execute_result") {
+                        } else if (out_data.msg_type === "stream") {
+                            html = marked(out_data.content.text);
+                            var t = html.match(/<p>([\s\S]*?)<\/p>/)[1]; //strip <p> and </p> that marked adds and we don't want
+                            html = t ? t : html;
+                            var q = html.match(/&#39;([\s\S]*?)&#39;/); // strip quotes from strings
+                            if (q !== null) html = q[1]
+                        } else if (out_data.msg_type === "execute_result" | out_data.msg_type === "display_data" ) {
                             var ul = out_data.content.data;
                             if (ul != undefined) {
                                 if (ul['text/latex'] != undefined) {

--- a/nbextensions/usability/python-markdown/readme.md
+++ b/nbextensions/usability/python-markdown/readme.md
@@ -2,7 +2,7 @@ Description
 ===========
 
 The **Python Markdown** extension allows displaying output produced by the currently kernel
-in markdown cells. The extensions is basically agnosic to the kernel language, however most
+in markdown cells. The extensions is basically agnostic to the kernel language, however most
 testing has been done using Python.
 
 For example:

--- a/nbextensions/usability/python-markdown/readme.md
+++ b/nbextensions/usability/python-markdown/readme.md
@@ -1,7 +1,10 @@
 Description
 ===========
 
-The **Python Markdown** extension allows displaying Python output in markdown cells.
+The **Python Markdown** extension allows displaying output produced by the currently kernel
+in markdown cells. The extensions is basically agnosic to the kernel language, however most
+testing has been done using Python.
+
 For example:
 If you set variable `a` in Python
 
@@ -12,13 +15,13 @@ a = 1.23
 and write the following line in a markdown cell:
 
 ```Markdown
-a = {{a}}
+a is {{a}}
 ```
 
 It will be displayed as:
 
 ```Markdown
-a = 1.23
+a is 1.23
 ```
 
 [![Demo Video](http://img.youtube.com/vi/_wLwLsgkExc/0.jpg)](https://youtu.be/_wLwLsgkExc)
@@ -30,7 +33,8 @@ This is indicated by the "trusted" check mark:
 
 If you see the "unstrusted" question mark, use File->Trust Notebook in the menu.
 
-**Caution: If you trust a notebook, you allow it to execute any Python code that is contained between the `{{...}}` curly braces on your PC.**
+**Caution: If you trust a notebook, you allow it to execute any code that is contained between the `{{...}}` 
+curly braces on your notebook server.**
 
 
 Further examples
@@ -44,17 +48,18 @@ After rendering the markdown cell:
 
 ![after](python-markdown-post.png)
 
-Python code is only executed when the notebook is trusted. So if your original Python code is still shown in 
-rendered markdown output, please make sure your notebook is trusted.
+Code is only executed when the notebook is trusted. So if your original code is shown as 
+rendered markdown output, please make sure your notebook is trusted. You can check if the notebook
+is trusted by looking at the check mark at the top of the window. 
 
-**Caution:** There is no restriction in the expression you can embedd in `{{ }}`. Be careful as you might crash your 
-browser if you return too large datasets.
+**Caution:** There is no restriction in the expression you can embedd between the curly braces `{{ }}`. 
+Be careful as you might crash your browser if you return too large datasets, or worse.
 
 
 Exporting
 =========
 
-In order to have `nbconvert` show the computed Python output when exporting to another format,
+In order to have `nbconvert` show the computed output when exporting to another format,
 use the `pre_pymarkdown.py` preprocessor. If you used the `python setup.py install` command to install the
 IPython-contrib extension package, this will already be installed.
 
@@ -70,11 +75,16 @@ c.Exporter.preprocessors = ['pre_pymarkdown.PyMarkdownPreprocessor']
 Internals
 =========
 
-The extension overrides the `textcell.MarkdownCell.prototype.render` function and searches for a Python expression enclosed in
-double curly braced `{{ <expr> }}`. It then executes the expression and replaces it with the result returned from Python, embedded
-in a `<span>` tag.
+The extension overrides the `textcell.MarkdownCell.prototype.render` function and searches for the expression enclosed 
+in double curly braced `{{ <expr> }}`. It then executes the expression and replaces it with the result returned from 
+the running kernel, embedded in a `<span>` tag.
 Additionally, the result is saved in the metadata of the markdown cell, i.e. `cell.metadata.variables[varname]`.
 This stored value is displayed when reloading the notebook and used for the nbconvert preprocesser.
 
 The preprocessor `pre_pymarkdown.PyMarkdownPreprocessor` allows `nbconvert` to display the computed variables
 when converting the notebook to an output file format.
+
+Unfortunately, embedding in LaTeX is not supported currently, as computing expressions between the curly braces
+and rendering LaTeX equations is happening asynchronously, and it is difficult to handle this in a consistent way.
+Ideas or pull request to implement this functionality are welcome.
+ 


### PR DESCRIPTION
Works with the Matlab kernel here.

I think a new name is needed for the extension. 'execute-markdown' ? Any ideas ?