### PR TITLE
CI fixes

### DIFF
--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -38,7 +38,7 @@ def get_installed_project_names():
 
 class MigrateTest(TestCase):
     """Tests for retiring old IPython-notebook-extensions installs."""
-    old_pkg_git_ref = 'master'
+    old_pkg_git_ref = 'c6d65e7826657a23c47b1fadbf8557a06e774db2'
     old_pkg_project_name = 'Python-contrib-nbextensions'
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ deps =
     coverage
     coveralls
 commands =
-    appveyor-artifacts --mangle-coverage download
+    appveyor-artifacts --owner-name=jcb91 --repo-name=ipython-notebook-extensions-ynb9f --mangle-coverage download
     ; tox doesn't run commands through a shell (makes windows inconsistent)
     ; So to get wildcard expansion, run through bash.
     ; Travis is the only place this env should be run, so it's ok to use bash.


### PR DESCRIPTION
to a ref before the restructure, otherwise the test doesn't make sense (and fails!)